### PR TITLE
Fix Gemini API call to use GenerationConfig object

### DIFF
--- a/book_generator/llm_api.py
+++ b/book_generator/llm_api.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 import time
 
+from google.genai.types import GenerationConfig
 import google.genai as genai
 import requests
 from dotenv import load_dotenv
@@ -126,7 +127,7 @@ def _call_gemini_api_internal(prompt, config, cache_prefix=None):
             # logging.info(f"Gemini API Prompt for model '{model_name}' (first 500 chars):\n{prompt[:500]}...")
 
         client = genai.Client()
-        generation_config = {"temperature": temperature}
+        generation_config = GenerationConfig(temperature=temperature)
 
         # Count tokens for Gemini prompt
         try:


### PR DESCRIPTION
The previous code was passing a dictionary for the `generation_config` parameter, which is no longer supported in the new version of the `google-genai` library. This change updates the code to use the `GenerationConfig` object as required, and also corrects the import statement for the library.