### PR TITLE
Fix Gemini API call keyword argument

### DIFF
--- a/book_generator/llm_api.py
+++ b/book_generator/llm_api.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 import time
 
+from google.genai.types import GenerationConfig
 import google.genai as genai
 import requests
 from dotenv import load_dotenv
@@ -126,7 +127,7 @@ def _call_gemini_api_internal(prompt, config, cache_prefix=None):
             # logging.info(f"Gemini API Prompt for model '{model_name}' (first 500 chars):\n{prompt[:500]}...")
 
         client = genai.Client()
-        generation_config = {"temperature": temperature}
+        generation_config = GenerationConfig(temperature=temperature)
 
         # Count tokens for Gemini prompt
         try:
@@ -147,7 +148,7 @@ def _call_gemini_api_internal(prompt, config, cache_prefix=None):
                 response = client.models.generate_content(
                     model=model_name,
                     contents=prompt,
-                    generation_config=generation_config,
+                    config=generation_config,
                     safety_settings=safety_settings,
                     stream=stream_gemini,
                 )


### PR DESCRIPTION
The previous code was using the incorrect keyword argument `generation_config` when calling the `generate_content` method. This has been corrected to use the proper `config` keyword argument.