### PR TITLE
Fix: Generate summary for fiction and record subtitle

### DIFF
--- a/book_generator/common_generator.py
+++ b/book_generator/common_generator.py
@@ -623,6 +623,7 @@ def generate_front_matter(
 
     # Subtitle generation already calls call_llm_api with its own prefix
     book_subtitle = generate_book_subtitle(config, book_title, summary_context)
+    config.get("generation_params", {})["book_subtitle"] = book_subtitle
 
     front_matter["title_page"] = {
         "title": book_title,

--- a/book_generator/orchestrator.py
+++ b/book_generator/orchestrator.py
@@ -105,6 +105,11 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
     else:
         summary_context = "[No chapter summaries available]"
 
+    # --- Generate Overall Summary and Save to Markdown ---
+    overall_summary_text = generate_overall_summary(config, book_title, summary_context)
+    save_summary_to_markdown(book_title, overall_summary_text, output_base_dir)
+    # --- End Overall Summary Generation ---
+
     logging.info("--- Generating Front Matter, Back Matter, and Marketing Content ---")
     front_matter_content = generate_front_matter(
         config,


### PR DESCRIPTION
This commit fixes two issues:

1.  The `_Summary.md` file was not being generated for fiction books. This was because the `run_generation_process_fiction` function in `orchestrator.py` was missing the calls to `generate_overall_summary` and `save_summary_to_markdown`. These calls have been added, mirroring the non-fiction generation process.

2.  The book subtitle was not being recorded in the marketing file. The subtitle was generated in `generate_front_matter` but not saved back to the main config object. The `generate_front_matter` function in `common_generator.py` has been updated to store the generated subtitle in `config['generation_params']['book_subtitle']`, making it available to the marketing document generation logic.