### PR TITLE
Feat: Generate genre-specific writing tone

### DIFF
--- a/book_generator/common_generator.py
+++ b/book_generator/common_generator.py
@@ -180,26 +180,28 @@ Output in British English."""
         return None
 
 
-def generate_writing_tone(config):
+def generate_writing_tone(config, is_fiction=False):
     """Generates a suitable writing tone using the Gemini API."""
-    logging.info("Auto-generating writing tone...")
+    logging.info(f"Auto-generating writing tone (is_fiction: {is_fiction})...")
     main_topic = config.get("generation_params", {}).get(
         "main_topic", "[No Main Topic Provided]"
     )
     setting = config.get("generation_params", {}).get(
-        "setting", "[No  Setting Provided]"
+        "setting", "[No Setting Provided]"
     )
 
-    if main_topic == "[No Main Topic Provided]" or setting == "[No  Setting Provided]":
+    genre_prompt_part = "a fictional novel" if is_fiction else "a non-fiction book"
+
+    if main_topic == "[No Main Topic Provided]" or setting == "[No Setting Provided]":
         logging.error(
             "Cannot generate specific writing tone without 'main_topic' and 'setting'. Using a generic prompt."
         )
         prompt = f"""Generate some words describing a suitable writing tone
-for a book. Output only the phrase describing the tone. Do not add introductory
+for {genre_prompt_part}. Output only the phrase describing the tone. Do not add introductory
 text. Output in British English."""
     else:
         prompt = f"""Based on the main topic '{main_topic}', a setting described as:
-"{setting}", generate some words describing the most suitable writing tone for a book exploring this
+"{setting}", generate some words describing the most suitable writing tone for {genre_prompt_part} exploring this
 topic. Output *only* the phrase describing the tone. Do not add introductory
 text. Output in British English."""
     tone_text = call_llm_api(prompt, config, cache_prefix="writing_tone")

--- a/book_generator/fiction_generator.py
+++ b/book_generator/fiction_generator.py
@@ -9,7 +9,7 @@ from book_generator.llm_api import call_llm_api
 from book_generator.utils import sanitize_filename
 
 
-def generate_overall_story(config, character_context=""):
+def generate_overall_story(config, character_context="", writing_tone=""):
     """Generates the overall story for a fiction book."""
     logging.info("Generating overall story...")
     main_topic = config.get("generation_params", {}).get("main_topic", "[No Main Topic Provided]")
@@ -23,6 +23,7 @@ Based on the main topic '{main_topic}', a setting described as:
 Write a  detailed overall story of about 2000 words. This story will serve as the master plot for the entire book.
 The story should have a clear beginning, middle, and end.
 It should introduce the main conflict, develop the plot, and provide a resolution.
+The writing tone should be: {writing_tone}.
 Output only the story text. Do not add introductory text.
 Output in British English.
 """
@@ -41,7 +42,7 @@ Output in British English.
         return None
 
 
-def generate_fiction_chapter_outline(config, overall_story, character_context="", fiction_chapter_count=20):
+def generate_fiction_chapter_outline(config, overall_story, character_context="", fiction_chapter_count=20, writing_tone=""):
     """Generates a list of chapter titles and summaries for a fiction book."""
     logging.info("Generating fiction chapter outline (titles and summaries)...")
     prompt = f"""
@@ -55,6 +56,7 @@ And the following characters:
 
 Break down the story into {fiction_chapter_count} chapters. For each chapter, provide a title and a one-paragraph summary.
 The chapters should logically follow the progression of the story.
+The writing tone for the summaries should be: {writing_tone}.
 
 Format the output as a numbered list of chapters. For each chapter, provide the title and then the summary.
 Example:
@@ -95,6 +97,7 @@ def generate_fiction_chapter_content(
     previous_chapter_summary,
     chapter_title,
     character_context="",
+    writing_tone="",
 ):
     """Generates the content for a single fiction chapter."""
     logging.info(f"Generating content for fiction chapter: '{chapter_title}'...")
@@ -106,11 +109,13 @@ Context:
 - Previous Chapter Title: '{previous_chapter_title}'
 - Previous Chapter Summary: '{previous_chapter_summary}'
 - Current Chapter Title: '{chapter_title}'
+- Writing Tone: {writing_tone}
 
 Task:
 Write a detailed chapter for the book, focusing on the story elements relevant to the current chapter title.
 The chapter should be approximately 2000 words long.
 Ensure the chapter is distinct from the previous chapter and logically follows the overall story.
+Adhere strictly to the specified writing tone.
 Avoid repetition.
 
 Instructions:

--- a/book_generator/orchestrator.py
+++ b/book_generator/orchestrator.py
@@ -55,7 +55,7 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
 
     # 2. Create an overall story based on the prompt.
     logging.info("--- Generating Overall Story ---")
-    overall_story = generate_overall_story(config, character_context_for_prompts)
+    overall_story = generate_overall_story(config, character_context_for_prompts, writing_tone)
     if not overall_story:
         logging.critical("Fatal: Failed to generate the overall story. Exiting.")
         sys.exit(1)
@@ -63,7 +63,13 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
     # 3. Break down the story into chapters.
     logging.info("--- Generating Fiction Chapter Outline (Titles and Summaries) ---")
     fiction_chapter_count = generation_params.get("fiction_chapter_count", 20)
-    chapters = generate_fiction_chapter_outline(config, overall_story, character_context_for_prompts, fiction_chapter_count)
+    chapters = generate_fiction_chapter_outline(
+        config,
+        overall_story,
+        character_context_for_prompts,
+        fiction_chapter_count,
+        writing_tone,
+    )
     if not chapters:
         logging.critical("Fatal: Failed to generate chapter outline. Exiting.")
         sys.exit(1)
@@ -86,6 +92,7 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
             previous_chapter_summary,
             chapter_title,
             character_context_for_prompts,
+            writing_tone,
         )
 
         body_matter[chapter_title] = [{"title": "", "content": chapter_content}]
@@ -618,7 +625,8 @@ def run_generation_process():
         logging.info(
             "No 'writing_tone' found or it was empty in config. Attempting to auto-generate one."
         )
-        generated_tone = generate_writing_tone(config)
+        is_fiction = generation_params.get("is_fiction", False)
+        generated_tone = generate_writing_tone(config, is_fiction=is_fiction)
         if generated_tone:
             writing_tone = generated_tone
             generation_params["writing_tone"] = (


### PR DESCRIPTION
When a `writing_tone` is not provided in the configuration, the system will now generate a tone that is appropriate for the book's genre (fiction or non-fiction).

This is achieved by:
1.  Updating `generate_writing_tone` in `common_generator.py` to accept an `is_fiction` flag and modify its prompt accordingly.
2.  Updating `orchestrator.py` to pass the `is_fiction` flag when calling `generate_writing_tone`.