### PR TITLE
Refactor: Remove overall_story from chapter generation

### DIFF
--- a/book_generator/fiction_generator.py
+++ b/book_generator/fiction_generator.py
@@ -92,10 +92,10 @@ Output in British English.
 
 def generate_fiction_chapter_content(
     config,
-    overall_story,
     previous_chapter_title,
     previous_chapter_summary,
     chapter_title,
+    chapter_summary,
     character_context="",
     writing_tone="",
 ):
@@ -104,17 +104,17 @@ def generate_fiction_chapter_content(
 
     prompt = f"""
 Context:
-- Book's Overall Story: {overall_story}
 - Characters: {character_context}
 - Previous Chapter Title: '{previous_chapter_title}'
 - Previous Chapter Summary: '{previous_chapter_summary}'
 - Current Chapter Title: '{chapter_title}'
+- Current Chapter Summary: '{chapter_summary}'
 - Writing Tone: {writing_tone}
 
 Task:
-Write a detailed chapter for the book, focusing on the story elements relevant to the current chapter title.
+Write a detailed chapter for the book, based on its summary, focusing on the story elements relevant to the current chapter title.
 The chapter should be approximately 2000 words long.
-Ensure the chapter is distinct from the previous chapter and logically follows the overall story.
+Ensure the chapter is distinct from the previous chapter.
 Adhere strictly to the specified writing tone.
 Avoid repetition.
 

--- a/book_generator/orchestrator.py
+++ b/book_generator/orchestrator.py
@@ -87,10 +87,10 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
 
         chapter_content = generate_fiction_chapter_content(
             config,
-            overall_story,
             previous_chapter_title,
             previous_chapter_summary,
             chapter_title,
+            chapter_summary,
             character_context_for_prompts,
             writing_tone,
         )


### PR DESCRIPTION
This change refactors the `generate_fiction_chapter_content` function to remove the `overall_story` parameter. The `overall_story` is not necessary for generating individual chapter content, as the chapter summary now provides sufficient context. This change simplifies the function and makes it more focused. The call to this function in the orchestrator has been updated to reflect this change.