### PR TITLE
feat: update fiction generation prompt

### DIFF
--- a/book_generator/fiction_generator.py
+++ b/book_generator/fiction_generator.py
@@ -93,9 +93,8 @@ Output in British English.
 def generate_fiction_chapter_content(
     config,
     previous_chapter_title,
-    previous_chapter_summary,
+    previous_chapter_content,
     chapter_title,
-    chapter_summary,
     character_context="",
     writing_tone="",
 ):
@@ -106,9 +105,8 @@ def generate_fiction_chapter_content(
 Context:
 - Characters: {character_context}
 - Previous Chapter Title: '{previous_chapter_title}'
-- Previous Chapter Summary: '{previous_chapter_summary}'
+- Previous Chapter Content: '{previous_chapter_content}'
 - Current Chapter Title: '{chapter_title}'
-- Current Chapter Summary: '{chapter_summary}'
 - Writing Tone: {writing_tone}
 
 Task:
@@ -116,7 +114,7 @@ Write a detailed chapter for the book, based on its summary, focusing on the sto
 The chapter should be approximately 2000 words long.
 Ensure the chapter is distinct from the previous chapter.
 Adhere strictly to the specified writing tone.
-Avoid repetition.
+Avoid repetition and the structure of the previous chapter.
 
 Instructions:
 - Output *only* the text content for this chapter.

--- a/book_generator/orchestrator.py
+++ b/book_generator/orchestrator.py
@@ -79,6 +79,7 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
     body_matter = {}
     previous_chapter_title = ""
     previous_chapter_summary = ""
+    previous_chapter_content = ""
 
     for i, chapter in enumerate(chapters):
         chapter_title = chapter.get("title")
@@ -89,6 +90,7 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
             config,
             previous_chapter_title,
             previous_chapter_summary,
+            previous_chapter_content,
             chapter_title,
             chapter_summary,
             character_context_for_prompts,
@@ -99,6 +101,7 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
 
         previous_chapter_title = chapter_title
         previous_chapter_summary = chapter_summary
+        previous_chapter_content = chapter_content
 
     summary_parts = []
     for i, chapter in enumerate(chapters):


### PR DESCRIPTION
This change updates the fiction generation prompt to use the previous chapter's content instead of its summary. It also removes the current chapter's summary from the prompt context. A new instruction has been added to the prompt to encourage the LLM to avoid the structure of the previous chapter and to avoid repetitiveness.