### PR TITLE
Fix(fiction): Correct arguments for generate_fiction_chapter_content

### DIFF
--- a/book_generator/orchestrator.py
+++ b/book_generator/orchestrator.py
@@ -89,10 +89,8 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
         chapter_content = generate_fiction_chapter_content(
             config,
             previous_chapter_title,
-            previous_chapter_summary,
             previous_chapter_content,
             chapter_title,
-            chapter_summary,
             character_context_for_prompts,
             writing_tone,
         )


### PR DESCRIPTION
Resolves a TypeError that occurred during fiction book generation. The function `generate_fiction_chapter_content` was being called with `previous_chapter_summary` and `chapter_summary` arguments, which it does not accept.

This change removes the two extra arguments from the function call in `book_generator/orchestrator.py` to match the function's signature in `book_generator/fiction_generator.py`.