### PR TITLE
Refactor: Use chapter outline for chapter content generation

### DIFF
--- a/book_generator/fiction_generator.py
+++ b/book_generator/fiction_generator.py
@@ -92,7 +92,7 @@ Output in British English.
 
 def generate_fiction_chapter_content(
     config,
-    overall_story,
+    chapter_outline,
     previous_chapter_title,
     previous_chapter_content,
     chapter_title,
@@ -111,9 +111,9 @@ Avoid repeating the structure and content of the previous chapter.
 
 Here is the context for your writing:
 
---- Overall Story ---
-{overall_story}
---- End Overall Story ---
+--- Chapter Outline ---
+{chapter_outline}
+--- End Chapter Outline ---
 
 --- Previous Chapter ---
 Title: {previous_chapter_title}

--- a/book_generator/orchestrator.py
+++ b/book_generator/orchestrator.py
@@ -76,6 +76,9 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
 
     # 4. Write each chapter.
     logging.info("--- Generating Fiction Chapter Content ---")
+    chapter_outline_str = "\n".join(
+        [f"{i+1}. {c['title']}: {c['summary']}" for i, c in enumerate(chapters)]
+    )
     body_matter = {}
     previous_chapter_title = ""
     previous_chapter_summary = ""
@@ -88,7 +91,7 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
 
         chapter_content = generate_fiction_chapter_content(
             config,
-            overall_story,
+            chapter_outline_str,
             previous_chapter_title,
             previous_chapter_content,
             chapter_title,


### PR DESCRIPTION
In `fiction_generator.py`, the `generate_fiction_chapter_content` function now uses the chapter outline instead of the overall story as context for generating chapter content.

This change includes:
- Modifying the `generate_fiction_chapter_content` function to accept a `chapter_outline` string.
- Updating the prompt in `generate_fiction_chapter_content` to use the new `chapter_outline`.
- Adjusting the `run_generation_process_fiction` function in `orchestrator.py` to format the chapter outline and pass it to the content generation function.