### PR TITLE
feat: Terminate program on repeated API failures

### DIFF
--- a/book_generator/llm_api.py
+++ b/book_generator/llm_api.py
@@ -260,10 +260,16 @@ def _call_gemini_api_internal(prompt, config, cache_prefix=None):
         logging.error(
             f"Gemini API call for model {model_name} failed after {max_retries} attempts."
         )
+        if api_settings_conf.get("terminate_on_api_failure", False):
+            logging.critical("Terminating program due to repeated API failures.")
+            sys.exit(1)
         return None  # Explicitly return None after all retries fail
 
     except Exception as e:
         logging.error(f"An unexpected error occurred during Gemini API call setup: {e}")
+        if api_settings_conf.get("terminate_on_api_failure", False):
+            logging.critical("Terminating program due to unexpected API error.")
+            sys.exit(1)
         return None
 
 
@@ -461,6 +467,11 @@ def _call_ollama_api_internal(prompt, config, cache_prefix=None):
             logging.error(
                 f"Ollama API call for model '{model_name}' failed after {max_retries} attempts."
             )
+            if api_settings_conf.get("terminate_on_api_failure", False):
+                logging.critical(
+                    "Terminating program due to repeated API failures."
+                )
+                sys.exit(1)
             return None
     return None  # Should be covered by loop logic, but as a safeguard
 

--- a/config.yaml
+++ b/config.yaml
@@ -78,6 +78,7 @@ api_settings:
   provider: "gemini"  # Can be "gemini" or "ollama" (Update as per your previous change)
 
   # Default settings applicable to API calls, can be overridden by provider-specific sections.
+  terminate_on_api_failure: true
   default_max_retries: 10
   default_retry_delay_seconds: 30
   base_cache_dir: "api_cache"     # Base directory for API call caching


### PR DESCRIPTION
This commit introduces a new feature to terminate the program if an API call fails after a specified number of retries.

- A new configuration option `terminate_on_api_failure` has been added to `config.yaml`.
- The API call functions in `book_generator/llm_api.py` now check this flag and exit the program if it's set to true and the API calls fail repeatedly.