### PR TITLE
Refactor: Use previous chapter summaries for fiction generation context

### DIFF
--- a/book_generator/fiction_generator.py
+++ b/book_generator/fiction_generator.py
@@ -92,7 +92,7 @@ Output in British English.
 
 def generate_fiction_chapter_content(
     config,
-    chapter_outline,
+    previous_chapters_summary,
     previous_chapter_title,
     previous_chapter_content,
     chapter_title,
@@ -111,9 +111,9 @@ Avoid repeating the structure and content of the previous chapter.
 
 Here is the context for your writing:
 
---- Chapter Outline ---
-{chapter_outline}
---- End Chapter Outline ---
+--- Summary of Previous Chapters ---
+{previous_chapters_summary}
+--- End Summary of Previous Chapters ---
 
 --- Previous Chapter ---
 Title: {previous_chapter_title}

--- a/book_generator/orchestrator.py
+++ b/book_generator/orchestrator.py
@@ -76,22 +76,24 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
 
     # 4. Write each chapter.
     logging.info("--- Generating Fiction Chapter Content ---")
-    chapter_outline_str = "\n".join(
-        [f"{i+1}. {c['title']}: {c['summary']}" for i, c in enumerate(chapters)]
-    )
     body_matter = {}
     previous_chapter_title = ""
     previous_chapter_summary = ""
     previous_chapter_content = ""
+    previous_chapters_summaries = []
 
     for i, chapter in enumerate(chapters):
         chapter_title = chapter.get("title")
         chapter_summary = chapter.get("summary")
         logging.info(f"--- Generating Content for Chapter {i+1}: {chapter_title} ---")
 
+        previous_chapters_summary_str = "\n".join(previous_chapters_summaries)
+        if not previous_chapters_summary_str:
+            previous_chapters_summary_str = "This is the first chapter."
+
         chapter_content = generate_fiction_chapter_content(
             config,
-            chapter_outline_str,
+            previous_chapters_summary_str,
             previous_chapter_title,
             previous_chapter_content,
             chapter_title,
@@ -105,6 +107,11 @@ def run_generation_process_fiction(config, output_base_dir, equation_image_dir):
         previous_chapter_title = chapter_title
         previous_chapter_summary = chapter_summary
         previous_chapter_content = chapter_content
+        if chapter_title and chapter_summary:
+            summary_entry = (
+                f"Chapter {i + 1} ('{chapter_title}'): {chapter_summary.strip()}"
+            )
+            previous_chapters_summaries.append(summary_entry)
 
     summary_parts = []
     for i, chapter in enumerate(chapters):


### PR DESCRIPTION
Instead of providing the entire book's chapter outline to the fiction chapter generation function, this change modifies the process to supply a summary of only the preceding chapters. This provides a more focused and relevant context for generating the current chapter's content.

Changes include:
- Modified `generate_fiction_chapter_content` to accept `previous_chapters_summary`.
- Updated the calling logic in `run_generation_process_fiction` to accumulate and pass the summary of previously generated chapters.