### PR TITLE
feat: Expose all Ollama parameters in config.yaml

### DIFF
--- a/book_generator/llm_api.py
+++ b/book_generator/llm_api.py
@@ -294,13 +294,9 @@ def _call_ollama_api_internal(prompt, config, cache_prefix=None):
 
     base_url = ollama_config.get("base_url", "http://localhost:11434")
     model_name = ollama_config.get("model", "llama3")  # Default Ollama model
-    temperature = float(ollama_config.get("temperature", 0.7))
     tokenizer_model_name = ollama_config.get(
         "tokenizer_model", "NousResearch/Llama-3-8B-Instruct-hf"
     )  # Default Llama3 tokenizer
-    context_window_size = ollama_config.get(
-        "context_window_size", None
-    )  # Default to None if not specified
 
     max_retries = int(ollama_config.get("max_retries", default_max_retries))
     retry_delay = int(ollama_config.get("retry_delay_seconds", default_retry_delay))
@@ -314,26 +310,44 @@ def _call_ollama_api_internal(prompt, config, cache_prefix=None):
         verbose_debug  # Specifically for Ollama streaming if verbose_debug is on
     )
 
+    # Prepare payload, starting with basic info
     payload = {
         "model": model_name,
         "prompt": prompt,
         "stream": stream_ollama,
-        "options": {
-            "temperature": temperature,
-            # num_ctx will be added below if specified
-        },
+        "options": {},  # Initialize empty options
     }
 
-    if context_window_size is not None:
-        try:
-            payload["options"]["num_ctx"] = int(context_window_size)
-            logging.info(
-                f"Ollama context window size (num_ctx) set to: {payload['options']['num_ctx']}"
-            )
-        except ValueError:
-            logging.error(
-                f"Invalid 'context_window_size' value: {context_window_size}. It must be an integer. Using Ollama's default."
-            )
+    # Get all llm_options from the config
+    llm_options = ollama_config.get("llm_options", {})
+    if llm_options:
+        logging.info(f"Applying Ollama llm_options: {llm_options}")
+        # Iterate through the provided llm_options and add them to the payload's options
+        for key, value in llm_options.items():
+            if value is not None:  # Ensure not to add keys with None value
+                payload["options"][key] = value
+                logging.debug(f"Set Ollama option '{key}': {value}")
+
+    # For backward compatibility, check for standalone temperature if not in llm_options
+    if "temperature" not in payload["options"] and "temperature" in ollama_config:
+        payload["options"]["temperature"] = float(ollama_config["temperature"])
+        logging.info(
+            f"Applying standalone 'temperature' setting: {payload['options']['temperature']}"
+        )
+
+    # For backward compatibility, handle standalone context_window_size
+    if "num_ctx" not in payload["options"] and "context_window_size" in ollama_config:
+        context_window_size = ollama_config.get("context_window_size")
+        if context_window_size is not None:
+            try:
+                payload["options"]["num_ctx"] = int(context_window_size)
+                logging.info(
+                    f"Applying standalone 'context_window_size' as num_ctx: {payload['options']['num_ctx']}"
+                )
+            except (ValueError, TypeError):
+                logging.error(
+                    f"Invalid 'context_window_size' value: {context_window_size}. It must be an integer. Ignoring."
+                )
 
     if verbose_debug:
         logging.info(f"Ollama API Prompt for model '{model_name}':\n{prompt}")

--- a/config.yaml
+++ b/config.yaml
@@ -109,11 +109,41 @@ api_settings:
     # tokenizer_model: "meta-llama/Llama-3.1-8B" # Tokenizer for client-side counting
 
     temperature: 0.4
+
+    # Full list of Ollama parameters that can be overriden.
+    # For more details, please visit: https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
+    llm_options:
+      # The temperature of the model. Increasing the temperature will make the model answer more creatively. (Default: 0.8)
+      temperature: 0.4
+      # Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt. (Default: 0)
+      # seed: 42
+      # The size of the context window used to generate the next token.
+      # num_ctx: 4096
+      # The number of layers to send to the GPU(s). On macOS it defaults to 1 to enable metal support, 0 to disable.
+      # num_gpu: 50
+      # Sets the number of threads to use during computation. By default, Ollama will detect this for optimal performance. It is recommended to set this value to half the number of physical CPU cores.
+      # num_thread: 8
+      # Sets how far back for the model to look back to prevent repetition. (Default: 64, 0 = disabled, -1 = num_ctx)
+      # repeat_last_n: 64
+      # Sets how strongly to penalize repetitions. A higher value (e.g., 1.5) will penalize repetitions more strongly. Increase the value to decrease repetition. (Default: 1.1)
+      repeat_penalty: 1.1
+      # Enable Mirostat sampling for controlling perplexity. (default: 0, 0 = disabled, 1 = Mirostat, 2 = Mirostat 2.0)
+      # mirostat: 0
+      # Influences how quickly the algorithm responds to feedback from the generated text. A lower learning rate will result in slower adjustments, while a higher learning rate will make the algorithm more responsive. (Default: 0.1)
+      # mirostat_eta: 0.1
+      # Controls the balance between coherence and diversity of the output. A lower value will result in more focused and coherent text. (Default: 5.0)
+      # mirostat_tau: 5.0
+      # Reduces the probability of generating nonsense. A higher value (e.g. 100) will give more diverse answers, while a lower value (e.g. 10) will be more conservative. (Default: 40)
+      # top_k: 40
+      # Works together with top-k. A higher value (e.g., 0.95) will lead to more diverse text, while a lower value (e.g., 0.5) will generate more focused and conservative text. (Default: 0.9)
+      # top_p: 0.9
+      # Tail free sampling is used to reduce the impact of less probable tokens from the output. A higher value (e.g., 2.0) will reduce the impact more, while a value of 1.0 disables this setting. (default: 1)
+      # tfs_z: 1.0
+
     # To use Ollama-specific retries different from default:
     max_retries: 10
     retry_delay_seconds: 5
     request_timeout_seconds: 180       # Timeout for Ollama requests (e.g., 3 minutes)
-    #context_window_size: 64000
 
 style_params:
   font_name: "Cambria"


### PR DESCRIPTION
This change exposes all available Ollama generation parameters in the `config.yaml` file under the `ollama.llm_options` key. This allows for fine-grained control over the Ollama model's generation process, including parameters to control repetition.

The `_call_ollama_api_internal` function in `book_generator/llm_api.py` has been updated to dynamically read these parameters and include them in the API request. Backward compatibility for the old `temperature` and `context_window_size` parameters is maintained.