### PR TITLE
Refactor docx newline replacement logic

### DIFF
--- a/book_generator/docx_builder.py
+++ b/book_generator/docx_builder.py
@@ -20,7 +20,11 @@ from book_generator.constants import (
     DEFAULT_INLINE_MATH_HEIGHT_MULTIPLIER,
     DEFAULT_WRITING_TONE,
 )
-from book_generator.utils import render_latex_to_image, sanitize_filename
+from book_generator.utils import (
+    clean_text_for_docx,
+    render_latex_to_image,
+    sanitize_filename,
+)
 
 # Helper function to apply formatting to a run
 def apply_formatting(run, bold=False, italic=False):
@@ -1450,8 +1454,7 @@ def assemble_docx(
         first_cp_p = doc.add_paragraph()
         first_cp_p.paragraph_format.space_before = Pt(60)
 
-        # Replace internal newlines with spaces before adding
-        first_para_text = re.sub(r"\s*\n\s*", " ", cp_paragraphs[0].strip())
+        first_para_text = clean_text_for_docx(cp_paragraphs[0])
         first_cp_p.add_run(first_para_text)
 
         first_cp_p.alignment = WD_PARAGRAPH_ALIGNMENT.LEFT
@@ -1461,8 +1464,7 @@ def assemble_docx(
 
         # Add subsequent paragraphs
         for cp_para in cp_paragraphs[1:]:
-            # Replace internal newlines with spaces before adding
-            para_text = re.sub(r"\s*\n\s*", " ", cp_para.strip())
+            para_text = clean_text_for_docx(cp_para)
             p = doc.add_paragraph(para_text)
 
             p.alignment = WD_PARAGRAPH_ALIGNMENT.LEFT

--- a/book_generator/utils.py
+++ b/book_generator/utils.py
@@ -163,3 +163,13 @@ def render_latex_to_image(
         )
         plt.close(fig)
         return None
+
+def clean_text_for_docx(text):
+    """
+    Replaces internal newlines (and surrounding whitespace) with a single space.
+    This is useful for ensuring that text content in DOCX paragraphs does not
+    have unexpected line breaks.
+    """
+    if not text:
+        return ""
+    return re.sub(r"\s*\n\s*", " ", text.strip())

--- a/tests/test_utils_text_cleaning.py
+++ b/tests/test_utils_text_cleaning.py
@@ -1,0 +1,41 @@
+import unittest
+from book_generator.utils import clean_text_for_docx
+
+class TestCleanTextForDocx(unittest.TestCase):
+    def test_basic_replacement(self):
+        text = "Hello\nWorld"
+        expected = "Hello World"
+        self.assertEqual(clean_text_for_docx(text), expected)
+
+    def test_multiple_newlines(self):
+        text = "Hello\n\nWorld"
+        expected = "Hello World"
+        self.assertEqual(clean_text_for_docx(text), expected)
+
+    def test_surrounding_whitespace(self):
+        text = "Hello \n   World"
+        expected = "Hello World"
+        self.assertEqual(clean_text_for_docx(text), expected)
+
+    def test_no_newlines(self):
+        text = "Hello World"
+        expected = "Hello World"
+        self.assertEqual(clean_text_for_docx(text), expected)
+
+    def test_empty_string(self):
+        text = ""
+        expected = ""
+        self.assertEqual(clean_text_for_docx(text), expected)
+
+    def test_none_input(self):
+        text = None
+        expected = ""
+        self.assertEqual(clean_text_for_docx(text), expected)
+
+    def test_strips_outer_whitespace(self):
+        text = "  Hello World  \n "
+        expected = "Hello World"
+        self.assertEqual(clean_text_for_docx(text), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change refactors the manual regex replacement of internal newlines in `docx_builder.py` into a reusable utility function `clean_text_for_docx`. This removes the redundant comments and ensures consistent text cleaning behavior. A new unit test file was added to verify the text cleaning logic.

---
*PR created automatically by Jules for task [4539210243485197307](https://jules.google.com/task/4539210243485197307) started by @fangfufu*